### PR TITLE
Use public tf-chainguard provider

### DIFF
--- a/github-issue-opener/README.md
+++ b/github-issue-opener/README.md
@@ -54,13 +54,5 @@ echo -n YOUR GITHUB PAT | \
 The personal access token needs permission to open issues on the target
 repository.
 
-
-Once the secret has been setup, grab the `url` output and the `group` we passed
-in and run:
-
-```shell
-chainctl event subscriptions create URL --group=GROUP
-```
-
 That's it!  Now policy failures during continuous verification will open
 github issues outlining the policy violation.

--- a/image-copy-ecr/iac/chainguard.tf
+++ b/image-copy-ecr/iac/chainguard.tf
@@ -15,13 +15,13 @@ resource "chainguard_identity" "aws" {
 }
 
 # Look up the registry.pull role to grant the identity.
-data "chainguard_roles" "puller" {
+data "chainguard_role" "puller" {
   name = "registry.pull"
 }
 
 resource "chainguard_rolebinding" "puller" {
   identity = chainguard_identity.aws.id
-  role     = data.chainguard_roles.puller.items[0].id
+  role     = data.chainguard_role.puller.items[0].id
   group    = var.group
 }
 

--- a/image-copy-ecr/iac/main.tf
+++ b/image-copy-ecr/iac/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws        = { source = "hashicorp/aws" }
-    chainguard = { source = "chainguard/chainguard" }
+    chainguard = { source = "chainguard-dev/chainguard" }
     ko         = { source = "ko-build/ko" }
   }
 }
@@ -10,4 +10,8 @@ provider "aws" {}
 
 provider "ko" {}
 
-provider "chainguard" {}
+provider "chainguard" {
+  login_options {
+    enabled = true
+  }
+}

--- a/image-copy-ecr/iac/main.tf
+++ b/image-copy-ecr/iac/main.tf
@@ -5,13 +5,3 @@ terraform {
     ko         = { source = "ko-build/ko" }
   }
 }
-
-provider "aws" {}
-
-provider "ko" {}
-
-provider "chainguard" {
-  login_options {
-    enabled = true
-  }
-}

--- a/image-copy-gcr/iac/main.tf
+++ b/image-copy-gcr/iac/main.tf
@@ -1,9 +1,9 @@
 terraform {
   required_providers {
-    ko         = { source = "ko-build/ko" }
-    google     = { source = "hashicorp/google" }
     chainguard = { source = "chainguard-dev/chainguard" }
     cosign     = { source = "chainguard-dev/cosign" }
+    google     = { source = "hashicorp/google" }
+    ko         = { source = "ko-build/ko" }
   }
 }
 
@@ -15,14 +15,9 @@ provider "google" {
   project = var.project_id
 }
 
-provider "chainguard" {
-  login_options {
-    enabled = true
-  }
-}
-
-provider "ko" {}
+provider "chainguard" {}
 provider "cosign" {}
+provider "ko" {}
 
 resource "google_service_account" "image-copy" {
   account_id = "${var.name}-image-copy"

--- a/image-copy-gcr/iac/main.tf
+++ b/image-copy-gcr/iac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ko         = { source = "ko-build/ko" }
     google     = { source = "hashicorp/google" }
-    chainguard = { source = "chainguard/chainguard" }
+    chainguard = { source = "chainguard-dev/chainguard" }
     cosign     = { source = "chainguard-dev/cosign" }
   }
 }
@@ -14,6 +14,15 @@ locals {
 provider "google" {
   project = var.project_id
 }
+
+provider "chainguard" {
+  login_options {
+    enabled = true
+  }
+}
+
+provider "ko" {}
+provider "cosign" {}
 
 resource "google_service_account" "image-copy" {
   account_id = "${var.name}-image-copy"
@@ -127,7 +136,7 @@ resource "chainguard_identity" "puller-identity" {
 }
 
 # Look up the registry.pull role to grant the identity.
-data "chainguard_roles" "puller" {
+data "chainguard_role" "puller" {
   name = "registry.pull"
 }
 
@@ -135,7 +144,7 @@ data "chainguard_roles" "puller" {
 resource "chainguard_rolebinding" "puller" {
   identity = chainguard_identity.puller-identity.id
   group    = var.group
-  role     = data.chainguard_roles.puller.items[0].id
+  role     = data.chainguard_role.puller.items[0].id
 }
 
 # Create a subscription to notify the Cloud Run service on changes under the root group.

--- a/jira-issue-opener/README.md
+++ b/jira-issue-opener/README.md
@@ -54,12 +54,5 @@ echo -n YOUR ATLASSIAN API TOKEN | \
 The personal access token needs permission to open issues on the target
 repository.
 
-Once the secret has been setup, grab the `url` output and the `group` we passed
-in and run:
-
-```shell
-chainctl event subscriptions create URL --group=GROUP
-```
-
 That's it!  Now policy failures during continuous verification will open
 Jira issues outlining the policy violation.

--- a/jira-issue-opener/iac/main.tf
+++ b/jira-issue-opener/iac/main.tf
@@ -1,14 +1,9 @@
 terraform {
   required_providers {
-    cosign = {
-      source = "chainguard-dev/cosign"
-    }
-    ko = {
-      source = "ko-build/ko"
-    }
-    google = {
-      source = "hashicorp/google"
-    }
+    chainguard = { source = "chainguard-dev/chainguard" }
+    cosign     = { source = "chainguard-dev/cosign" }
+    google     = { source = "hashicorp/google" }
+    ko         = { source = "ko-build/ko" }
   }
 }
 
@@ -25,7 +20,7 @@ resource "google_secret_manager_secret" "jira-token" {
   project   = var.project_id
   secret_id = "${var.name}-jira-token"
   replication {
-    automatic = true
+    auto {}
   }
 }
 
@@ -156,4 +151,10 @@ resource "google_cloud_run_service_iam_policy" "noauth" {
   service  = google_cloud_run_service.jira-iss.name
 
   policy_data = data.google_iam_policy.noauth.policy_data
+}
+
+// Subscribe to events under the root group.
+resource "chainguard_subscription" "subscription" {
+  parent_id = var.group
+  sink      = google_cloud_run_service.jira-iss.status[0].url
 }

--- a/slack-webhook/README.md
+++ b/slack-webhook/README.md
@@ -52,13 +52,5 @@ Create a Slack Webhook URL as detailed in the
 [Incoming webhooks for Slack](https://slack.com/help/articles/115005265063-Incoming-webhooks-for-Slack)
 help document, and run the above command!
 
-
-Once the secret has been setup, grab the `url` output and the `group` we passed
-in and run:
-
-```shell
-chainctl event subscriptions create URL --group=GROUP
-```
-
 That's it!  Now policy failures during continuous verification will
 post notifications to slack outlining the policy violation.

--- a/slack-webhook/iac/main.tf
+++ b/slack-webhook/iac/main.tf
@@ -1,14 +1,9 @@
 terraform {
   required_providers {
-    cosign = {
-      source = "chainguard-dev/cosign"
-    }
-    ko = {
-      source = "ko-build/ko"
-    }
-    google = {
-      source = "hashicorp/google"
-    }
+    chainguard = { source = "chainguard-dev/chainguard" }
+    cosign     = { source = "chainguard-dev/cosign" }
+    google     = { source = "hashicorp/google" }
+    ko         = { source = "ko-build/ko" }
   }
 }
 
@@ -25,7 +20,7 @@ resource "google_secret_manager_secret" "slack-url" {
   project   = var.project_id
   secret_id = "${var.name}-slack-url"
   replication {
-    automatic = true
+    auto {}
   }
 }
 
@@ -82,7 +77,7 @@ resource "ko_build" "image" {
   importpath  = local.importpath
   working_dir = path.module
   # repo overrides KO_DOCKER_REPO environment variable
-  repo        = "gcr.io/${var.project_id}/${local.importpath}"
+  repo = "gcr.io/${var.project_id}/${local.importpath}"
 }
 
 resource "cosign_sign" "image" {
@@ -149,4 +144,10 @@ resource "google_cloud_run_service_iam_policy" "noauth" {
   service  = google_cloud_run_service.slack-notifier.name
 
   policy_data = data.google_iam_policy.noauth.policy_data
+}
+
+// Subscribe to events under the root group.
+resource "chainguard_subscription" "subscription" {
+  parent_id = var.group
+  sink      = google_cloud_run_service.slack-notifier.status[0].url
 }


### PR DESCRIPTION
This started as an exercise to update the image-copy examples to use the correct released TF provider.

After that it grew to update the other events examples to use the TF provider to set up subscriptions, now that we can do that. I noticed these examples also used something that must have been changed in some version of the Google TF provider.