### PR TITLE
do anonymous auth by exchanging from real identity

### DIFF
--- a/tag-history/cmd/app/main.go
+++ b/tag-history/cmd/app/main.go
@@ -7,11 +7,8 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
-	"io"
 	"log"
-	"net/http"
 	"strings"
 	"time"
 
@@ -49,47 +46,27 @@ func main() {
 	var tok string
 	audience := "https://console-api.enforce.dev"
 	{
+		if token.RemainingLife(audience, time.Minute) < 0 {
+			// TODO: do a browser flow here.
+			log.Fatalf("token has expired, please run `chainctl auth login`")
+		}
+		tokb, err := token.Load(audience)
+		if err != nil {
+			log.Fatalf("loading token: %v", err)
+		}
+		tok = string(tokb)
+
 		if group == "chainguard" {
 			// This group is special, since anybody can access it by assuming a
 			// broadly-assumable identity with permission to view/pull.
 
 			issuer := "https://issuer.enforce.dev"
-			resp, err := http.Get("https://justtrustme.dev/token?aud=" + issuer)
-			if err != nil {
-				log.Fatalf("getting justtrustme token: %v", err)
-			}
-			defer resp.Body.Close()
-			if resp.StatusCode != http.StatusOK {
-				log.Fatalf("getting justtrustme token: %v", resp.Status)
-			}
-			all, err := io.ReadAll(resp.Body)
-			if err != nil {
-				log.Fatalf("reading justtrustme token: %v", err)
-			}
-			var r struct {
-				Token string `json:"token"`
-			}
-			if err := json.Unmarshal(all, &r); err != nil {
-				log.Fatalf("decoding justtrustme token: %v", err)
-			}
-			tok = r.Token
-
 			tok, err = sts.New(issuer, audience,
 				sts.WithIdentity("720909c9f5279097d847ad02a2f24ba8f59de36a/a033a6fabe0bfa0d")).
 				Exchange(ctx, tok)
 			if err != nil {
 				log.Fatalf("exchanging token: %v", err)
 			}
-		} else {
-			if token.RemainingLife(audience, time.Minute) < 0 {
-				// TODO: do a browser flow here.
-				log.Fatalf("token has expired, please run `chainctl auth login`")
-			}
-			tokb, err := token.Load(audience)
-			if err != nil {
-				log.Fatalf("loading token: %v", err)
-			}
-			tok = string(tokb)
 		}
 	}
 

--- a/tag-history/go.mod
+++ b/tag-history/go.mod
@@ -8,7 +8,6 @@ replace github.com/chainguard-dev/enforce-events => ../
 
 require (
 	chainguard.dev/sdk v0.1.1
-	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-containerregistry v0.16.1
 )
 

--- a/tag-history/go.sum
+++ b/tag-history/go.sum
@@ -47,8 +47,6 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
This removes a dependency on justtrustme.dev, which is not monitored.

Instead, callers must have a Chainguard account already, which we'll use to exchange creds for the public puller identity, to get public tag history.