### PR TITLE
WIP: add terraform-pull-token module

### DIFF
--- a/terraform-pull-token/README.md
+++ b/terraform-pull-token/README.md
@@ -1,0 +1,32 @@
+# `terraform-pull-token`
+
+This module creates a token that can be used to pull images from a private registry.
+It's intended to be equivalent to [`chainctl auth configure-docker --pull-token`](https://edu.chainguard.dev/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-docker/).
+
+### Usage
+
+```
+terraform apply \
+  -var=group=[ROOT-GROUP-ID] \
+  -var=name=[UNIQUE-IDENTITY-NAME]
+```
+
+When this completes it will output some values:
+
+```
+Outputs:
+
+command = <sensitive>
+password = <sensitive>
+username = "7bf0abc1e47a927f78fabc9cd6393f4a83ec6eb7/2d3d8f583b8df855"
+```
+
+The `password` in sensitive, which means you need to use the `terraform output -raw` command to see it.
+
+```
+$ terraform output -raw command
+docker login -u "7bf0abc1e47a927f78fabc9cd6393f4a83ec6eb7/2d3d8f583b8df855" -p "eyJhbG...oMtQ" https://cgr.dev
+```
+
+You can run this command to log in using the pull token you just created.
+

--- a/terraform-pull-token/main.tf
+++ b/terraform-pull-token/main.tf
@@ -1,0 +1,84 @@
+terraform {
+  required_providers {
+    chainguard = { source = "chainguard-dev/chainguard" }
+    jwt        = { source = "camptocamp/jwt" }
+  }
+}
+
+variable "group" {
+  description = "Group to own the pull token"
+  type        = string
+}
+
+variable "name" {
+  description = "Name of the pull token"
+  type        = string
+}
+
+variable "ttl_days" {
+  description = "TTL of the pull token in days"
+  type        = number
+  default     = 30
+}
+
+resource "tls_private_key" "key" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "time_static" "time" {}
+resource "random_id" "hex" { byte_length = 4 }
+
+resource "chainguard_identity" "assumable-identity" {
+  parent_id = var.group
+  name      = var.name
+
+  static {
+    expiration = timeadd(time_static.time.rfc3339, "${var.ttl_days * 24}h")
+    issuer     = "https://pulltoken.issuer.chainguard.dev"
+    subject    = "terraform-pull-token-${random_id.hex.hex}"
+    issuer_keys = jsonencode({
+      keys = [{
+        algorithm = "RS256"
+        key       = base64encode(tls_private_key.key.public_key_pem)
+      }]
+    })
+  }
+}
+
+// Grant the assumable identity the ability to assume the puller role.
+data "chainguard_role" "puller" { name = "registry.pull" }
+
+resource "chainguard_rolebinding" "puller" {
+  group    = var.group
+  identity = chainguard_identity.assumable-identity.id
+  role     = data.chainguard_role.puller.items[0].id
+}
+
+resource "jwt_signed_token" "token" {
+  algorithm = "RS256"
+  claims_json = jsonencode({
+    iss = "https://pulltoken.issuer.chainguard.dev"
+    iat = time_static.time.unix
+    exp = time_static.time.unix + (var.ttl_days * 24 * 60 * 60)
+    sub = "terraform-pull-token-${random_id.hex.hex}"
+    aud = ["https://issuer.enforce.dev"]
+  })
+  key = tls_private_key.key.private_key_pem
+}
+
+output "username" {
+  value = chainguard_identity.assumable-identity.id
+}
+
+output "password" {
+  value     = jwt_signed_token.token.token
+  sensitive = true
+}
+
+output "command" {
+  value     = <<EOC
+docker login -u "${chainguard_identity.assumable-identity.id}" -p "${jwt_signed_token.token.token}" https://cgr.dev
+    EOC
+  sensitive = true
+}

--- a/terraform-pull-token/terraform.tfvars
+++ b/terraform-pull-token/terraform.tfvars
@@ -1,0 +1,2 @@
+group = "7bf08061e47a927f78ffa39cd6393f4a83ec6eb7"
+name  = "terraform-pull-token"


### PR DESCRIPTION
Draft while I debug why the token it generates isn't accepted

```
terraform output -raw command | bash
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
Error response from daemon: Get "https://cgr.dev/v2/": unknown: Forbidden
```