### PR TITLE
minor tweaks to improve user experience in image-copy-gcp example

### DIFF
--- a/image-copy-gcp/README.md
+++ b/image-copy-gcp/README.md
@@ -9,7 +9,7 @@ it like this:
 
 ```
 module "image-copy" {
-  source = "github.com/chainguard-dev/platform-examples//image-copy-gcp/iac"
+  source = "github.com/chainguard-dev/platform-examples/image-copy-gcp/iac"
 
   # name is used to prefix resources created by this demo application
   # where possible.

--- a/image-copy-gcp/README.md
+++ b/image-copy-gcp/README.md
@@ -9,7 +9,7 @@ it like this:
 
 ```
 module "image-copy" {
-  source = "github.com/chainguard-dev/platform-examples/image-copy-gcp/iac"
+  source = "github.com/chainguard-dev/platform-examples//image-copy-gcp/iac"
 
   # name is used to prefix resources created by this demo application
   # where possible.

--- a/image-copy-gcp/iac/main.tf
+++ b/image-copy-gcp/iac/main.tf
@@ -15,7 +15,6 @@ provider "google" {
   project = var.project_id
 }
 
-provider "chainguard" {}
 provider "cosign" {}
 provider "ko" {}
 


### PR DESCRIPTION
@erikaheidi kindly reviewed my recent draft for a [companion piece](https://edu.chainguard.dev/chainguard/administration/cloudevents/image-copy-gcr/) to the `image-copy-gcp` example. In the process she flagged a few weird things that might be worth fixing so users aren't confused when following our docs.

The first change removes what seems to be an extra `/` from the `README` example.

The second change removes a line that causes a warning to come up when running the current example:

```
│ Warning: Redundant empty provider block
│ 
│   on .terraform/modules/image-copy/image-copy-gcp/iac/main.tf line 18:
│   18: provider "chainguard" {}
│ 
│ Earlier versions of Terraform used empty provider blocks ("proxy provider configurations") for child modules to declare their
│ need to be passed a provider configuration by their callers. That approach was ambiguous and is now deprecated.
│ 
│ If you control this module, you can migrate to the new declaration syntax by removing all of the empty provider "chainguard"
│ blocks and then adding or updating an entry like the following to the required_providers block of module.image-copy:
│     chainguard = {
│       source = "chainguard-dev/chainguard"
│     }
│ 
│ (and 2 more similar warnings elsewhere)
```

I tested out removing the line specified in the warning. Everything still works and I didn't receive the warning!