### PR TITLE
Remove references to policy violations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 This repo holds a number of example apps demonstrating integrations with Chainguard platform APIs, and various [Chainguard Events](https://edu.chainguard.dev/chainguard/chainguard-enforce/reference/events/).
 
-- [GitHub Issue Opener](./github-issue-opener/README.md) - opens an issue in GitHub when a policy is violated
-- [Slack Webhook](./slack-webhook/README.md) - sends a message to a Slack channel when a policy is violated
-- [Jira Issuer Opener](./jira-issue-opener/) - opens an issue in Jira when a policy is violated
 - [GCP Image Copier](./image-copy-gcp/) - copies images to Google Artifact Registry when an image is pushed to cgr.dev
 - [ECR Image Copier](./image-copy-ecr/) - copies images to Amazon Elastic Container Registry when an image is pushed to cgr.dev
 - [AWS Auth Example](./aws-auth/) - demonstrates configuration of an AWS assumable Chainguard identity, as well as calling the Chainguard API from a Lambda function
@@ -18,8 +15,8 @@ This repo holds a number of example apps demonstrating integrations with Chaingu
 > For example:
 
 ```hcl
-module "github-issue-opener" {
-  source = "github.com/chainguard-dev/platform-examples//github-issue-opener/iac?ref=a1b2c3d4"
+module "image-copy" {
+  source = "github.com/chainguard-dev/platform-examples/image-copy-gcp/iac?ref=a1b2c3d4"
 
   project_id = "..."
   group      = "..."


### PR DESCRIPTION
I removed the references to policy violations in the README. 

So far, I've not removed the old code for sending violations to slack/github/jira but we probably should -- I assume no-one can be depending on this any more?