### PR TITLE
image-copy-ecr: Delete non-empty sub-repo

### DIFF
--- a/image-copy-ecr/iac/lambda.tf
+++ b/image-copy-ecr/iac/lambda.tf
@@ -76,6 +76,7 @@ resource "aws_ecr_repository" "repo" {
 resource "aws_ecr_repository" "copier-repo" {
   name                 = "${var.dst_repo}/image-copy"
   image_tag_mutability = "MUTABLE"
+  force_delete         = true
 
   image_scanning_configuration {
     scan_on_push = false


### PR DESCRIPTION
This commit forces the non-empty sub-repo to be deleted.  The ko provider does not support deleting images from a repository at this time.  This sub-repo was created by the example and only contain the image that the example pushes to it.