### PR TITLE
image-copy-{ecr,gcp}: optionally ignore referrers

### DIFF
--- a/image-copy-ecr/README.md
+++ b/image-copy-ecr/README.md
@@ -12,19 +12,52 @@ The Terraform does everything:
 
 ## Setup
 
+Create a `.tfvars` file.
+
+```
+cat << EOF > iac/terraform.tfvars
+# Required. The name of your Chainguard organization.
+group_name = "your.org"
+
+# Required. The name of the destination repo where images should be copied to.
+# This repository will be created by the terraform and images will be copied to
+# '<dst_repo>/<image_name>'.
+dst_repo = "image-copy"
+
+# Optional. Ignore signatures and attestations. This can help reduce cruft in
+# the mirror repositories if you aren't going to be verifying or using the
+# referrers.
+# ignore_referrers = true
+
+# Optional. Enable immutable tags for the repositories created by the Lambda.
+# If enabled, then the Lambda will append a portion of the digest to the tags
+# it copies. For instance: 'latest-abcdef'
+# immutable_tags = true
+EOF
+```
+
+Login to AWS and Chainguard.
+
 ```sh
 aws sso login --profile my-profile
 chainctl auth login
-terraform init
-terraform apply
 ```
 
-This will prompt for your group name and destination repo, and show you the resources it will create.
+Apply the terraform.
 
-When the resources are created, any images that are pushed to your group will be mirrored to the ECR repository.
+```sh
+cd iac/
+terraform init
+terraform apply -var-file=terraform.tfvars
+```
 
-The Lambda function has minimal permissions: it's only allowed to push images to the destination repo and its sub-repos.
+When the resources are created, any images that are pushed to your group will
+be mirrored to the ECR repository.
 
-The Chainguard identity also has minimal permissions: it only has permission to pull from the source repo.
+The Lambda function has minimal permissions: it's only allowed to push images
+to the destination repo and its sub-repos.
 
-To tear down resources, run `terraform destroy`.
+The Chainguard identity also has minimal permissions: it only has permission to
+pull from the source repo.
+
+To tear down resources, run `terraform destroy -var-file=terraform.tfvars`.

--- a/image-copy-ecr/iac/lambda.tf
+++ b/image-copy-ecr/iac/lambda.tf
@@ -107,17 +107,20 @@ resource "aws_lambda_function" "lambda" {
   package_type = "Image"
   image_uri    = ko_build.image.image_ref
 
+  timeout = 300
+
   environment {
     variables = {
-      GROUP_NAME     = var.group_name
-      GROUP          = data.chainguard_group.group.id
-      IDENTITY       = chainguard_identity.aws.id
-      ISSUER_URL     = "https://issuer.enforce.dev"
-      API_ENDPOINT   = "https://console-api.enforce.dev"
-      DST_REPO       = var.dst_repo
-      FULL_DST_REPO  = aws_ecr_repository.repo.repository_url
-      REGION         = data.aws_region.current.name
-      IMMUTABLE_TAGS = var.immutable_tags
+      GROUP_NAME       = var.group_name
+      GROUP            = data.chainguard_group.group.id
+      IDENTITY         = chainguard_identity.aws.id
+      ISSUER_URL       = "https://issuer.enforce.dev"
+      API_ENDPOINT     = "https://console-api.enforce.dev"
+      DST_REPO         = var.dst_repo
+      FULL_DST_REPO    = aws_ecr_repository.repo.repository_url
+      REGION           = data.aws_region.current.name
+      IMMUTABLE_TAGS   = var.immutable_tags
+      IGNORE_REFERRERS = var.ignore_referrers
     }
   }
 }

--- a/image-copy-ecr/iac/variables.tf
+++ b/image-copy-ecr/iac/variables.tf
@@ -13,3 +13,9 @@ variable "immutable_tags" {
   description = "Whether to enable immutable tags."
   default     = false
 }
+
+variable "ignore_referrers" {
+  type        = bool
+  description = "Whether to ignore events for signatures and attestations."
+  default     = false
+}

--- a/image-copy-gcp/README.md
+++ b/image-copy-gcp/README.md
@@ -34,6 +34,9 @@ module "image-copy" {
 
   # Location of the Artifact Registry repository, and the Cloud Run subscriber.
   # location = "us-central1" (default)
+
+  # Don't copy referrers like signatures and attestations
+  # ignore_referrers = true
 }
 ```
 

--- a/image-copy-gcp/iac/main.tf
+++ b/image-copy-gcp/iac/main.tf
@@ -91,6 +91,10 @@ resource "google_cloud_run_service" "image-copy" {
           name  = "DST_REPO"
           value = "${var.location}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.dst-repo.name}"
         }
+        env {
+          name  = "IGNORE_REFERRERS"
+          value = var.ignore_referrers
+        }
       }
     }
   }

--- a/image-copy-gcp/iac/variables.tf
+++ b/image-copy-gcp/iac/variables.tf
@@ -28,3 +28,9 @@ variable "dst_repo" {
   type        = string
   description = "The destination repo where images should be copied to."
 }
+
+variable "ignore_referrers" {
+  type        = bool
+  description = "Whether to ignore events for signatures and attestations."
+  default     = false
+}


### PR DESCRIPTION
If customers aren't familiar with cosign then the sea of `sha256-abcdef...` tags in the mirror repositories can be confusing and make it unnecessarily difficult to understand the available tags, especially if they have no intention of doing anything with the signatures and attestations.

This change adds a variable (`ignore_referrers`) that disables the mirroring of signatures and attestations.

I've updated the READMEs to document this variable.

I've also lengthened the timeout on the `image-copy-ecr` Lambda. The default of 3 seconds is far too short and I was running into timeouts while testing this change.