### PR TITLE
remove ko_build provider

### DIFF
--- a/image-copy-ecr/Dockerfile
+++ b/image-copy-ecr/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.23.4-alpine3.20 AS builder
+
+WORKDIR /app
+
+COPY main.go .
+COPY go.mod .
+COPY go.sum .
+
+RUN go build -tags lambda.norpc -o app main.go
+
+
+FROM public.ecr.aws/lambda/provided:al2
+
+# Copy function code
+COPY --from=builder /app/app ./app
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+ENTRYPOINT [ "./app" ]

--- a/image-copy-ecr/iac/main.tf
+++ b/image-copy-ecr/iac/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws        = { source = "hashicorp/aws" }
     chainguard = { source = "chainguard-dev/chainguard" }
-    ko         = { source = "ko-build/ko" }
+    docker     = { source = "kreuzwerker/docker" }
+    random     = { source  = "hashicorp/random" }
   }
 }


### PR DESCRIPTION
Improved the ECR lambda example to use the docker provoider and a Dockerfile for lambda image building.  A random string is used in the tag to be able to more easily iterate and customize the lambda function getting deployed.